### PR TITLE
Hugging Face fetch fix

### DIFF
--- a/datahugger/api.py
+++ b/datahugger/api.py
@@ -272,7 +272,7 @@ def get(
         progress=progress,
         print_only=print_only,
         **kwargs,
-    ).download(output_folder, doi=doi)
+    ).download(output_folder, doi=doi, **kwargs)
 
 
 def info(

--- a/datahugger/base.py
+++ b/datahugger/base.py
@@ -71,6 +71,7 @@ class DatasetDownloader:
         progress=True,
         unzip=True,
         print_only=False,
+        **kwargs,
     ):
         super().__init__()
         self.url = url

--- a/datahugger/services.py
+++ b/datahugger/services.py
@@ -310,6 +310,8 @@ class HuggingFaceDataset(DatasetDownloader, DatasetResult):
         output_folder: Union[Path, str],
         **kwargs,
     ):
+        if "doi" in kwargs:
+            del kwargs["doi"]
 
         try:
             from datasets import load_dataset


### PR DESCRIPTION
Good evening,

Unfortunately, Hugging Face support does not seem to be working at the moment.

```python
import datahugger
datahugger.get("https://huggingface.co/datasets/wikitext")
```

will fail because `doi` gets passed into hf's `load_dataset` via the `kwargs` and it throws an error. Additionally, there was no way to pass the args needed to select an appropriate config for the dataset.

With these changes, the following now works:

```python
import datahugger
datahugger.get("https://huggingface.co/datasets/wikitext", name="wikitext-103-v1")
```

Not sure if this is the canonical way to get things working (`del kwargs['doi']` seems like a hack to me) but, this does get hf working again.

Thanks for this library, it was very helpful! ~<3