### PR TITLE
Fix case sensitive lookups in re3data software dict

### DIFF
--- a/datahugger/api.py
+++ b/datahugger/api.py
@@ -135,8 +135,9 @@ SERVICES_NETLOC_REGEXP = {
     r".*\/handle\/\d+\/\d+": DSpaceDataset,
 }
 
+# add keys in lower-case for fast case-insensitive lookups
 RE3DATA_SOFTWARE = {
-    "DataVerse": DataverseDataset,  # Hits on re3data 2022-09-02: (145)
+    "dataverse": DataverseDataset,  # Hits on re3data 2022-09-02: (145)
     # "DSpace": DSpaceDataset,  # Hits on re3data 2022-09-02: (115)
     # "CKAN": CKANDataset,  # Hits on re3data 2022-09-02: (89)
     # "MySQL": MySQLDataset,  # Hits on re3data 2022-09-02: (86)
@@ -353,4 +354,4 @@ def _resolve_service_with_re3data(doi):
 
             r_software = get_re3data_repository(repo["id"])
 
-            return RE3DATA_SOFTWARE[r_software]
+            return RE3DATA_SOFTWARE[r_software.lower()]


### PR DESCRIPTION
Hello!

Great little tool that could help us out a lot with automating the download process from certain data portals! Thanks for making this available to the research community!

I wanted to try it out, but bumped into a small issue, which I hope this PR fixes. When trying out a download from a Dataverse repository that is not in the fast lookup table `SERVICES_NETLOC`, the API resorted to the `RE3DATA_SOFTWARE` lookup table, where I got the following KeyError:

```
datahugger.get("https://doi.org/10.17026/dans-279-hy72", "data")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/datahugger/api.py", line 266, in get
    return _base_request(
  File "/usr/local/lib/python3.9/site-packages/datahugger/api.py", line 194, in _base_request
    return _base_request(
  File "/usr/local/lib/python3.9/site-packages/datahugger/api.py", line 205, in _base_request
    service_class = _resolve_service(url, doi)
  File "/usr/local/lib/python3.9/site-packages/datahugger/api.py", line 317, in _resolve_service
    service_class = _resolve_service_with_re3data(doi)
  File "/usr/local/lib/python3.9/site-packages/datahugger/api.py", line 356, in _resolve_service_with_re3data
    return RE3DATA_SOFTWARE[r_software]
KeyError: 'Dataverse'
```

The  dataset in question can be found here: https://ssh.datastations.nl/dataset.xhtml?persistentId=doi:10.17026/dans-279-hy72

'DataVerse' is however in the `RE3DATA_SOFTWARE` lookup table, but with a different case. I created this pull request to make the keys in `RE3DATA_SOFTWARE` case-insensitive.

Cheers,
Ahmad