### PR TITLE
Change ValueError into RepositoryNotSupportedError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 datahugger/_version.py
+benchmark/benchmark_datasets_tested.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/datahugger/__init__.py
+++ b/datahugger/__init__.py
@@ -8,7 +8,6 @@ __all__ = [
     "get",
     "info",
     "parse_resource_identifier",
-    "DataCiteError",
     "DOIError",
     "RepositoryNotSupportedError",
 ]

--- a/datahugger/resolvers.py
+++ b/datahugger/resolvers.py
@@ -7,6 +7,7 @@ import requests
 from datahugger.config import RE3DATA_SOFTWARE
 from datahugger.config import SERVICES_NETLOC
 from datahugger.config import SERVICES_NETLOC_REGEXP
+from datahugger.exceptions import RepositoryNotSupportedError
 from datahugger.handles import DOI
 from datahugger.utils import _get_url
 from datahugger.utils import get_datapublisher_from_doi
@@ -26,7 +27,7 @@ def _resolve_service(resource):
             logging.info(f"Service found: {service_class}")
             return service_class
 
-    raise ValueError(f"Data protocol for {resource} not found.")
+    raise RepositoryNotSupportedError(f"Data protocol for {resource} not found.")
 
 
 def _resolve_service_from_netloc(resource):


### PR DESCRIPTION
This PR introduces a new error for not supported repositories. This change might be breaking when you catch the ValueError for "Data protocol not found". 

```python
import datahugger

try:
    datahugger.get("my_doi", "data")
except datahugger.RepositoryNotSupportedError:
    print("Datahugger doesn't support this resource")
except Exception:
   print("Unexpected error")
```