### PR TITLE
Remove OSF storage integration test (temporarily)

### DIFF
--- a/tests/test_repositories.toml
+++ b/tests/test_repositories.toml
@@ -63,10 +63,6 @@ location = "https://doi.org/10.5061/dryad.31zcrjdm5"
 files = "ReadmeFile.txt"
 
 [[osf]]
-location = "https://osf.io/ews27/"
-files = "Cross-comparison/amarlt1"
-
-[[osf]]
 location = "https://osf.io/kq573/"
 files = "nest_area_data.xlsx"
 


### PR DESCRIPTION
Our OSF test for a dataset with integrated external storage fails at the moment because the storage is not available. I tried to find an alternative dataset, but so far I can't find a reliable alternative. I found a GitHub integration, however, that one takes forever to return the call. This might be caused by the large number of files in that repo. 

Does anyone have a good example of a dataset/project with external data that we can use for a test?

https://help.osf.io/article/555-add-ons-storage-api-integration-faq-s
